### PR TITLE
fixed: unicode characters in urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function gis(opts, done) {
       while ((result = re.exec(content)) !== null) {
         if (result.length > 3) {
           let ref = {
-            url: result[1],
+            url: unicodeToString(result[1]),
             width: +result[3],
             height: +result[2]
           };
@@ -106,6 +106,10 @@ function gis(opts, done) {
       }
     }
   }
+}
+
+function unicodeToString(content) {
+  return content.replace(/\\u[\dA-F]{4}/gi, (match) => String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16)))
 }
 
 function addSiteExcludePrefix(s) {


### PR DESCRIPTION
search `cats` got unicode urls which need to be string.
[current_url](https://people.com/thmb/MxXiL9Zo-tqwZXN4mPgrqYjOHoE//u003d/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():focal(554x222:556x224)/cat-friends-706db6fc872a456ab9e168eface0a390.jpg) after using `unicodeToString` [string_url](https://people.com/thmb/MxXiL9Zo-tqwZXN4mPgrqYjOHoE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():focal(554x222:556x224)/cat-friends-706db6fc872a456ab9e168eface0a390.jpg)

Test and accept the pull.
